### PR TITLE
Increased concurrency and have the handler send a message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,5 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+.idea

--- a/CRB.RabbitMQTest.Contracts/TestMessage.cs
+++ b/CRB.RabbitMQTest.Contracts/TestMessage.cs
@@ -5,5 +5,6 @@ namespace CRB.RabbitMQTest.Messages
     public class TestMessage
     {
         public int MillisecondsOfWork { get; set; }
+        public int TTL { get; set; }
     }
 }

--- a/RabbitMQSender/Program.cs
+++ b/RabbitMQSender/Program.cs
@@ -51,7 +51,7 @@ namespace RabbitMQSender
                     services.Configure<SenderOptions>(o =>
                     {
                         if (!int.TryParse(args.FirstOrDefault(), out var n))
-                            n = 100000;
+                            n = 100;
 
                         o.NumberToSend = n;
                     });

--- a/RabbitMQSender/Worker.cs
+++ b/RabbitMQSender/Worker.cs
@@ -30,7 +30,7 @@ namespace RabbitMQSender
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            var message = new TestMessage { MillisecondsOfWork = 0 };
+            var message = new TestMessage { MillisecondsOfWork = 0, TTL = 1000};
 
             await Task.WhenAll(Enumerable.Range(0, _options.NumberToSend).Select(x => MessageSession.Send(message)));
 

--- a/RabbitMQTester/Program.cs
+++ b/RabbitMQTester/Program.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
 
 namespace RabbitMQTester
 {
@@ -42,7 +43,9 @@ namespace RabbitMQTester
                     var sqlConnectionString = c.GetConnectionString("SQL");
 
                     var configuration = new EndpointConfiguration(endpointName);
-                    // configuration.LimitMessageProcessingConcurrencyTo(1000);
+
+                    // REVIEW: This uses the default concurrency limit which is number of cores, that is fine as the current task is CPU bound but if the task as IO bound increasing concurrency could be beneficial. But... as we are doing IO when sending audit messages the concurrently limit should be increased too.
+                    configuration.LimitMessageProcessingConcurrencyTo(Environment.ProcessorCount * 4);
 
                     configuration.LicensePath("NsbLicense2019.xml");
                     configuration.EnableInstallers();


### PR DESCRIPTION
Previous handler was not doing anything. If you now suddenly send a message for which the incoming operation waits until completes then this will significantly reduce throughput. Having a handler send an audit message on top of another message that it sends is a more fair comparison.

The test now create a batch of messages with a TTL of 1,000 sends.

Second, this type of operation benefits from increased concurrency. Set it to 4x the number of cores but even that might not be sufficient and needs to be increased even further.

Third, the handler now uses Task.Run for the fake load. That operation is CPU bound so should use Task.Run.

